### PR TITLE
Update Ali platform module driver and bug fixes.

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -226,7 +226,8 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     hping3                  \
     python-scapy            \
     tcptraceroute           \
-    mtr-tiny
+    mtr-tiny                \
+    dmidecode
 
 sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y download \
     grub-pc-bin

--- a/files/image_config/rsyslog/rsyslog.conf.j2
+++ b/files/image_config/rsyslog/rsyslog.conf.j2
@@ -19,7 +19,7 @@ $ModLoad imklog   # provides kernel logging support
 
 # provides UDP syslog reception
 $ModLoad imudp
-$UDPServerAddress fe80::2:1%eth0.4088 # bind to localhost before udp server run
+$UDPServerAddress 240.1.1.2 # bind to localhost before udp server run
 $UDPServerRun 1514
 
 # provides TCP syslog reception


### PR DESCRIPTION
- Remove i2c devices overlap bmc
- Disable imc bus create for 2nd channel.
- Update rsyslog UDPServerAddress
- Add dmidecode tool 