### PR TITLE
[platform/celestica] Seastone2 probe ipmi dev when os boot

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-seastone2.init
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-seastone2.init
@@ -17,6 +17,8 @@ start)
 
     # Add driver to support HW
     modprobe i2c-dev
+    modprobe ipmi_devintf
+    modprobe ipmi_si
     modprobe baseboard_cpld
     modprobe switchboard_fpga
     modprobe mc24lc64t

--- a/platform/broadcom/sonic-platform-modules-cel/seastone2/cfg/seastone2-modules.conf
+++ b/platform/broadcom/sonic-platform-modules-cel/seastone2/cfg/seastone2-modules.conf
@@ -12,4 +12,5 @@ i2c-smbus
 
 i2c-mux-gpio
 i2c-mux-pca954x
-
+ipmi_devintf
+ipmi_si


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Probe ipmi device when kernel boot.

**- How I did it**
 Add the ipmi_devintf and ipmi_si module in module auto probe list.

**- How to verify it**
When system boot up check for `/dev/ipmi0`.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
*Probe for ipmi device when OS boot.

**- A picture of a cute animal (not mandatory but encouraged)**
