### PR TITLE
[device/celestica] Fix incorrect port index in 128x100G config file.

### DIFF
--- a/device/celestica/x86_64-cel_silverstone-r0/Silverstone-128x100/port_config.ini
+++ b/device/celestica/x86_64-cel_silverstone-r0/Silverstone-128x100/port_config.ini
@@ -1,129 +1,129 @@
-# name		lanes		alias      index
-Ethernet0	33,34	    QSFP1         1
-Ethernet1 	35,36       QSFP2         2
-Ethernet2	37,38       QSFP3         3
-Ethernet3	39,40       QSFP4         4
-Ethernet4	41,42       QSFP5         5
-Ethernet5	43,44       QSFP6         6
-Ethernet6   45,46 	    QSFP7	      7
-Ethernet7   47,48    	QSFP8	      8
-Ethernet8	49,50 	    QSFP9         9
-Ethernet9 	51,52       QSFP10        10
-Ethernet10	53,54       QSFP11        11
-Ethernet11	55,56       QSFP12        12
-Ethernet12	57,58       QSFP13        13
-Ethernet13	59,60       QSFP14        14
-Ethernet14  61,62 	    QSFP15	      15
-Ethernet15  63,64    	QSFP16	      16
-Ethernet16	65,66	    QSFP17        17
-Ethernet17 	67,68       QSFP18        18
-Ethernet18	69,70       QSFP19        19
-Ethernet19	71,72       QSFP20        20
-Ethernet20	73,74       QSFP21        21
-Ethernet21	75,76       QSFP22        22
-Ethernet22  77,78	    QSFP23	      23
-Ethernet23  79,80       QSFP24	      24
-Ethernet24	81,82	    QSFP25        25
-Ethernet25 	83,84       QSFP26        26
-Ethernet26	85,86       QSFP27        27
-Ethernet27	87,88       QSFP28        28
-Ethernet28	89,90       QSFP29        29
-Ethernet29	91,92       QSFP30        30
-Ethernet30  93,94 	    QSFP31	      31
-Ethernet31  95,96    	QSFP32	      32
-Ethernet32	1,2         QSFP33        33
-Ethernet33 	3,4         QSFP34        34
-Ethernet34	5,6         QSFP35        35
-Ethernet35	7,8         QSFP36        36
-Ethernet36	9,10        QSFP37        37
-Ethernet37	11,12       QSFP38        38
-Ethernet38  13,14       QSFP39	      39
-Ethernet39  15,16       QSFP40	      40
-Ethernet40	17,18       QSFP41        41
-Ethernet41 	19,20       QSFP42        42
-Ethernet42	21,22       QSFP43        43
-Ethernet43	23,24       QSFP44        44
-Ethernet44	25,26       QSFP45        45
-Ethernet45	27,28       QSFP46        46
-Ethernet46  29,30       QSFP47        47
-Ethernet47  31,32       QSFP48        48
-Ethernet48	97,98       QSFP49        49
-Ethernet49 	99,100      QSFP50        50
-Ethernet50	101,102     QSFP51        51
-Ethernet51	103,104     QSFP52        52
-Ethernet52	105,106     QSFP53        53
-Ethernet53	107,108     QSFP54        54
-Ethernet54  109,110	    QSFP55	      55
-Ethernet55  111,112    	QSFP56	      56
-Ethernet56	113,114	    QSFP57        57
-Ethernet57 	115,116     QSFP58        58
-Ethernet58	117,118     QSFP59        59
-Ethernet59	119,120     QSFP60        60
-Ethernet60	121,122     QSFP61        61
-Ethernet61	123,124     QSFP62        62
-Ethernet62  125,126 	QSFP63	      63
-Ethernet63  127,128    	QSFP64	      64
-Ethernet64	129,130     QSFP65        65
-Ethernet65 	131,132     QSFP66        66
-Ethernet66	133,134     QSFP67        67
-Ethernet67	135,136     QSFP68        68
-Ethernet68	137,138     QSFP69        69
-Ethernet69	139,140     QSFP70        70
-Ethernet70  141,142     QSFP71	      71
-Ethernet71  143,144    	QSFP72	      72
-Ethernet72	145,146	    QSFP73        73
-Ethernet73 	147,148     QSFP74        74
-Ethernet74	149,150     QSFP75        75
-Ethernet75	151,152     QSFP76        76
-Ethernet76	153,154     QSFP77        77
-Ethernet77	155,156     QSFP78        78
-Ethernet78  157,158	    QSFP79	      79
-Ethernet79  159,160    	QSFP80	      80
-Ethernet80 	225,226     QSFP81        81
-Ethernet81	227,228     QSFP82        82
-Ethernet82	229,230     QSFP83        83
-Ethernet83	231,232     QSFP84        84
-Ethernet84	233,234     QSFP85        85
-Ethernet85  235,236	    QSFP86	      86
-Ethernet86  237,238    	QSFP87	      87
-Ethernet87	239,240	    QSFP88        88
-Ethernet88 	241,242     QSFP89        89
-Ethernet89	243,244     QSFP90        90
-Ethernet90	245,246     QSFP91        91
-Ethernet91	247,248     QSFP92        92
-Ethernet92	249,250     QSFP93        93
-Ethernet93  251,252	    QSFP94	      94
-Ethernet94  253,254    	QSFP95	      95
-Ethernet95	255,256	    QSFP96        96
-Ethernet96	161,162     QSFP97        97
-Ethernet97 	163,164     QSFP98        98
-Ethernet98	165,166     QSFP99        99
-Ethernet99	167,168     QSFP100       100
-Ethernet100	169,170     QSFP101       101
-Ethernet101	171,172     QSFP102       102
-Ethernet102 173,174     QSFP103	      103
-Ethernet103 175,176     QSFP104	      104
-Ethernet104	177,178	    QSFP105       105
-Ethernet105 179,180     QSFP106       106
-Ethernet106	181,182     QSFP107       107
-Ethernet107	183,184     QSFP108       108
-Ethernet108	185,186     QSFP109       109
-Ethernet109	187,188     QSFP110       110
-Ethernet110 189,190	    QSFP111	      111
-Ethernet111 191,192    	QSFP112	      112
-Ethernet112	193,194	    QSFP113       113
-Ethernet113 195,196     QSFP114       114
-Ethernet114	197,198     QSFP115       115
-Ethernet115	199,200     QSFP116       116
-Ethernet116	201,202     QSFP117       117
-Ethernet117	203,204     QSFP118       118
-Ethernet118 205,206    	QSFP119	      119
-Ethernet119 207,208    	QSFP120	      120
-Ethernet120	209,210	    QSFP121       121
-Ethernet121 211,212     QSFP122       122
-Ethernet122	213,214     QSFP123       123
-Ethernet123	215,216     QSFP124       124
-Ethernet124	217,218     QSFP125       125
-Ethernet125	219,220     QSFP126       126
-Ethernet126 221,222 	QSFP127	      127
-Ethernet127 223,224    	QSFP128	      128
+# name          lanes       alias           index       speed
+Ethernet0       33,34       QSFP1/1         1           100000
+Ethernet1       35,36       QSFP1/2         1           100000
+Ethernet2       37,38       QSFP1/3         1           100000
+Ethernet3       39,40       QSFP1/4         1           100000
+Ethernet4       41,42       QSFP2/1         2           100000
+Ethernet5       43,44       QSFP2/2         2           100000
+Ethernet6       45,46       QSFP2/3         2           100000
+Ethernet7       47,48       QSFP2/4         2           100000
+Ethernet8       49,50       QSFP3/1         3           100000
+Ethernet9       51,52       QSFP3/2         3           100000
+Ethernet10      53,54       QSFP3/3         3           100000
+Ethernet11      55,56       QSFP3/4         3           100000
+Ethernet12      57,58       QSFP4/1         4           100000
+Ethernet13      59,60       QSFP4/2         4           100000
+Ethernet14      61,62       QSFP4/3         4           100000
+Ethernet15      63,64       QSFP4/4         4           100000
+Ethernet16      65,66       QSFP5/1         5           100000
+Ethernet17      67,68       QSFP5/2         5           100000
+Ethernet18      69,70       QSFP5/3         5           100000
+Ethernet19      71,72       QSFP5/4         5           100000
+Ethernet20      73,74       QSFP6/1         6           100000
+Ethernet21      75,76       QSFP6/2         6           100000
+Ethernet22      77,78       QSFP6/3         6           100000
+Ethernet23      79,80       QSFP6/4         6           100000
+Ethernet24      81,82       QSFP7/1         7           100000
+Ethernet25      83,84       QSFP7/2         7           100000
+Ethernet26      85,86       QSFP7/3         7           100000
+Ethernet27      87,88       QSFP7/4         7           100000
+Ethernet28      89,90       QSFP8/1         8           100000
+Ethernet29      91,92       QSFP8/2         8           100000
+Ethernet30      93,94       QSFP8/3         8           100000
+Ethernet31      95,96       QSFP8/4         8           100000
+Ethernet32      1,2         QSFP9/1         9           100000
+Ethernet33      3,4         QSFP9/2         9           100000
+Ethernet34      5,6         QSFP9/3         9           100000
+Ethernet35      7,8         QSFP9/4         9           100000
+Ethernet36      9,10        QSFP10/1        10          100000
+Ethernet37      11,12       QSFP10/2        10          100000
+Ethernet38      13,14       QSFP10/3        10          100000
+Ethernet39      15,16       QSFP10/4        10          100000
+Ethernet40      17,18       QSFP11/1        11          100000
+Ethernet41      19,20       QSFP11/2        11          100000
+Ethernet42      21,22       QSFP11/3        11          100000
+Ethernet43      23,24       QSFP11/4        11          100000
+Ethernet44      25,26       QSFP12/1        12          100000
+Ethernet45      27,28       QSFP12/2        12          100000
+Ethernet46      29,30       QSFP12/3        12          100000
+Ethernet47      31,32       QSFP12/4        12          100000
+Ethernet48      97,98       QSFP13/1        13          100000
+Ethernet49      99,100      QSFP13/2        13          100000
+Ethernet50      101,102     QSFP13/3        13          100000
+Ethernet51      103,104     QSFP13/4        13          100000
+Ethernet52      105,106     QSFP14/1        14          100000
+Ethernet53      107,108     QSFP14/2        14          100000
+Ethernet54      109,110     QSFP14/3        14          100000
+Ethernet55      111,112     QSFP14/4        14          100000
+Ethernet56      113,114     QSFP15/1        15          100000
+Ethernet57      115,116     QSFP15/2        15          100000
+Ethernet58      117,118     QSFP15/3        15          100000
+Ethernet59      119,120     QSFP15/4        15          100000
+Ethernet60      121,122     QSFP16/1        16          100000
+Ethernet61      123,124     QSFP16/2        16          100000
+Ethernet62      125,126     QSFP16/3        16          100000
+Ethernet63      127,128     QSFP16/4        16          100000
+Ethernet64      129,130     QSFP17/1        17          100000
+Ethernet65      131,132     QSFP17/2        17          100000
+Ethernet66      133,134     QSFP17/3        17          100000
+Ethernet67      135,136     QSFP17/4        17          100000
+Ethernet68      137,138     QSFP18/1        18          100000
+Ethernet69      139,140     QSFP18/2        18          100000
+Ethernet70      141,142     QSFP18/3        18          100000
+Ethernet71      143,144     QSFP18/4        18          100000
+Ethernet72      145,146     QSFP19/1        19          100000
+Ethernet73      147,148     QSFP19/2        19          100000
+Ethernet74      149,150     QSFP19/3        19          100000
+Ethernet75      151,152     QSFP19/4        19          100000
+Ethernet76      153,154     QSFP20/1        20          100000
+Ethernet77      155,156     QSFP20/2        20          100000
+Ethernet78      157,158     QSFP20/3        20          100000
+Ethernet79      159,160     QSFP20/4        20          100000
+Ethernet80      225,226     QSFP21/1        21          100000
+Ethernet81      227,228     QSFP21/2        21          100000
+Ethernet82      229,230     QSFP21/3        21          100000
+Ethernet83      231,232     QSFP21/4        21          100000
+Ethernet84      233,234     QSFP22/1        22          100000
+Ethernet85      235,236     QSFP22/2        22          100000
+Ethernet86      237,238     QSFP22/3        22          100000
+Ethernet87      239,240     QSFP22/4        22          100000
+Ethernet88      241,242     QSFP23/1        23          100000
+Ethernet89      243,244     QSFP23/2        23          100000
+Ethernet90      245,246     QSFP23/3        23          100000
+Ethernet91      247,248     QSFP23/4        23          100000
+Ethernet92      249,250     QSFP24/1        24          100000
+Ethernet93      251,252     QSFP24/2        24          100000
+Ethernet94      253,254     QSFP24/3        24          100000
+Ethernet95      255,256     QSFP24/4        24          100000
+Ethernet96      161,162     QSFP25/1        25          100000
+Ethernet97      163,164     QSFP25/2        25          100000
+Ethernet98      165,166     QSFP25/3        25          100000
+Ethernet99      167,168     QSFP25/4        25          100000
+Ethernet100     169,170     QSFP26/1        26          100000
+Ethernet101     171,172     QSFP26/2        26          100000
+Ethernet102     173,174     QSFP26/3        26          100000
+Ethernet103     175,176     QSFP26/4        26          100000
+Ethernet104     177,178     QSFP27/1        27          100000
+Ethernet105     179,180     QSFP27/2        27          100000
+Ethernet106     181,182     QSFP27/3        27          100000
+Ethernet107     183,184     QSFP27/4        27          100000
+Ethernet108     185,186     QSFP28/1        28          100000
+Ethernet109     187,188     QSFP28/2        28          100000
+Ethernet110     189,190     QSFP28/3        28          100000
+Ethernet111     191,192     QSFP28/4        28          100000
+Ethernet112     193,194     QSFP29/1        29          100000
+Ethernet113     195,196     QSFP29/2        29          100000
+Ethernet114     197,198     QSFP29/3        29          100000
+Ethernet115     199,200     QSFP29/4        29          100000
+Ethernet116     201,202     QSFP30/1        30          100000
+Ethernet117     203,204     QSFP30/2        30          100000
+Ethernet118     205,206     QSFP30/3        30          100000
+Ethernet119     207,208     QSFP30/4        30          100000
+Ethernet120     209,210     QSFP31/1        31          100000
+Ethernet121     211,212     QSFP31/2        31          100000
+Ethernet122     213,214     QSFP31/3        31          100000
+Ethernet123     215,216     QSFP31/4        31          100000
+Ethernet124     217,218     QSFP32/1        32          100000
+Ethernet125     219,220     QSFP32/2        32          100000
+Ethernet126     221,222     QSFP32/3        32          100000
+Ethernet127     223,224     QSFP32/4        32          100000


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fix the incorrect port index mapping in port_config.ini file.
This bug cause sfputil to return invalid output.

**- How I did it**

Update the index column of 128x100G config file follows front panel port index.

**- How to verify it**

Run the following command and verify all port can be reset.
```
for i in {0..127..1}; do sudo sfputil reset Ethernet$i ; done 
```
Please see the output in the seperates test log(Shred drive)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

- fix Silverstone 128x100G incorrect port mapping.

**- A picture of a cute animal (not mandatory but encouraged)**
