### PR TITLE
[platform/broadcom] Update questone2bd switchboard driver

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-questone2bd.init
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-questone2bd.init
@@ -43,7 +43,9 @@ start)
         echo syscpld 0x0d > /sys/bus/i2c/devices/i2c-70/new_device
 
         ## Populate PSU PMBus and System CPLD devices
+        sleep 1
         echo dps1100 0x58 > /sys/bus/i2c/devices/i2c-75/new_device
+        sleep 1
         echo dps1100 0x59 > /sys/bus/i2c/devices/i2c-76/new_device
         
         # Populate temperature sensors


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Update the switchboard FPGA to fix the known bugs found on fishbone48
Update init script to make the platform start after first SONiC install.

**- How I did it**
Apply the fix to switchboard FPFA driver.
Add small delay in platform init script after initial PCA9548 i2c devices.

**- How to verify it**
* Install fresh SONIC from ONIE, see if all devices initialize successfully.
* The PSU and EEPROM devices can be probed correctly.
* FSC service is running.

**- Description for the changelog**
* Improve questone2bd platform driver.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
