### PR TITLE
[sonic_api] Implement function to get critical temperature value

### DIFF
--- a/device/celestica/x86_64-cel_questone2bd-r0/sonic_platform/thermal.py
+++ b/device/celestica/x86_64-cel_questone2bd-r0/sonic_platform/thermal.py
@@ -170,6 +170,26 @@ class Thermal(ThermalBase):
                 break
         return result
 
+    def get_high_critical_threshold(self):
+        """
+        Retrieves the high critical threshold temperature of thermal
+        Returns:
+            A float number, the high critical threshold temperature of thermal in Celsius
+            up to nearest thousandth of one degree Celsius, e.g. 30.125
+        """
+        temp_file = "temp{}_crit".format(self.ss_index)
+        return self.__get_temp(temp_file)
+
+    def get_low_critical_threshold(self):
+        """
+        Retrieves the low critical threshold temperature of thermal
+        Returns:
+            A float number, the low critical threshold temperature of thermal in Celsius
+            up to nearest thousandth of one degree Celsius, e.g. 30.125
+        """
+        temp_file = "temp{}_lcrit".format(self.ss_index)
+        return self.__get_temp(temp_file)
+
     ##############################################################
     ###################### Device methods ########################
     ##############################################################


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add function to get high/low critical threshold function to platform thermal. 
These are called by thermalctld in the latest Azure/201911 commit.

**- How I did it**
Implement the get_high_critical_threshold()
Implement the get_high_critical_threshold()

**- How to verify it**
Run the `show platform tepperature` and check output restlt.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Implement temperature critical value read on sonic_platform

Result:
```
admin@sonic:~$ show platform temperature 
                    NAME    Temperature    High Threshold    Low Threshold    Critical High Threshold    Critical Low Threshold    Warning Status          Timestamp
------------------------  -------------  ----------------  ---------------  -------------------------  ------------------------  ----------------  -----------------
         TEMP_core_tmp_1          64                   82              N/A                      104.0                       N/A             False  20200516 16:52:38
         TEMP_core_tmp_2          64                   82              N/A                      104.0                       N/A             False  20200516 16:52:38
         TEMP_core_tmp_3          64                   82              N/A                      104.0                       N/A             False  20200516 16:52:38
         TEMP_core_tmp_4          64                   82              N/A                      104.0                       N/A             False  20200516 16:52:38
TEMP_dps1100_i2c_75_58_1          37                   70              N/A                        N/A                       N/A             False  20200516 16:52:38
TEMP_dps1100_i2c_75_58_2          48.5                 70              N/A                        N/A                       N/A             False  20200516 16:52:38
TEMP_dps1100_i2c_76_59_1          39                   70              N/A                        N/A                       N/A             False  20200516 16:52:38
TEMP_dps1100_i2c_76_59_2          51.75                70              N/A                        N/A                       N/A             False  20200516 16:52:38
    TEMP_lm75b_i2c_67_4d          35.5                 80              N/A                        N/A                       N/A             False  20200516 16:52:38
     TEMP_lm75b_i2c_9_48          46.5                 97              N/A                        N/A                       N/A             False  20200516 16:52:38
  TEMP_syscpld_i2c_70_0d          60.67               104              N/A                        N/A                       N/A             False  20200516 16:52:38

```
