### PR TITLE
[platform/questone2bd] Fix DPS1100 crash after sonic kernel patched VID

### DIFF
--- a/platform/broadcom/sonic-platform-modules-cel/questone2bd/modules/pmbus.h
+++ b/platform/broadcom/sonic-platform-modules-cel/questone2bd/modules/pmbus.h
@@ -341,12 +341,12 @@ enum pmbus_sensor_classes {
 #define PMBUS_HAVE_STATUS_VMON	BIT(19)
 
 enum pmbus_data_format { linear = 0, direct, vid };
-enum vrm_version { vr11 = 0, vr12 };
+enum vrm_version { vr11 = 0, vr12, vr13, imvp9, amd625mv };
 
 struct pmbus_driver_info {
 	int pages;		/* Total number of pages */
 	enum pmbus_data_format format[PSC_NUM_CLASSES];
-	enum vrm_version vrm_version;
+	enum vrm_version vrm_version[PMBUS_PAGES]; /* vrm version per page */
 	/*
 	 * Support one set of coefficients for each sensor type
 	 * Used for chips providing data in direct mode.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fix the DPS1100 not working with [sonic-linux-kernel@32963dab](https://github.com/Azure/sonic-linux-kernel/commit/32963dab6b6ea9f9fbda9b2b49a77574453fb8ef)

**- How I did it**
Update the platform copy of pmbus.h to same with the patched one from sonic-linux-kernel.

**- How to verify it**
* Build the dps1100 with new pmbus.h and load it to kernel.
* Run `sensors` to see the driver is working.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Fix DPS100 crash with sonic-linux-kernel@32963dab on questone2bd

**Note**
:warning: If the kernel in your sonic is prior to 32963dab, please don't pick this change.

**Test log** 
[fix-dps1100-on-201911_cel_wb.log](https://github.com/SONIC-DEV/sonic-buildimage/files/4660682/fix-dps1100-on-201911_cel_wb.log)
