### PR TITLE
[device/platform] Implement xcvr insert/remove event on questone2bd

### DIFF
--- a/device/celestica/x86_64-cel_questone2bd-r0/sonic_platform/chassis.py
+++ b/device/celestica/x86_64-cel_questone2bd-r0/sonic_platform/chassis.py
@@ -9,11 +9,12 @@
 #############################################################################
 
 try:
-    import sys
-    import re
-    import os
-    import subprocess
     import json
+    import os
+    import re
+    import sys
+    import subprocess
+    import time
     from sonic_platform_base.chassis_base import ChassisBase
     from helper import APIHelper
 except ImportError as e:
@@ -25,6 +26,12 @@ NUM_PSU = 2
 NUM_THERMAL = 11
 NUM_SFP = 56
 NUM_COMPONENT = 7
+
+SFP_PORT_START = 1
+SFP_PORT_END = 48
+QSFP_PORT_START = 49
+QSFP_PORT_END = 56
+
 REBOOT_CAUSE_REG = "0xA106"
 TLV_EEPROM_I2C_BUS = 0
 TLV_EEPROM_I2C_ADDR = 56
@@ -32,6 +39,11 @@ TLV_EEPROM_I2C_ADDR = 56
 BASE_CPLD_PLATFORM = "questone2bd.cpldb"
 BASE_GETREG_PATH = "/sys/devices/platform/{}/getreg".format(BASE_CPLD_PLATFORM)
 
+SWITCH_BRD_PLATFORM = "questone2bd.switchboard"
+PORT_INFO_PATH = "/sys/devices/platform/{}/SFF".format(SWITCH_BRD_PLATFORM)
+PATH_INT_SYSFS = "{0}/{port_name}/{type_prefix}_isr_flags"
+PATH_INTMASK_SYSFS = "{0}/{port_name}/{type_prefix}_isr_mask"
+PATH_PRS_SYSFS = "{0}/{port_name}/{prs_file_name}"
 
 class Chassis(ChassisBase):
     """Platform-specific Chassis class"""
@@ -40,12 +52,14 @@ class Chassis(ChassisBase):
         ChassisBase.__init__(self)
         self._api_helper = APIHelper()
         self.sfp_module_initialized = False
+        self.POLL_INTERVAL = 1
 
         if not self._api_helper.is_host():
             self.__initialize_fan()
             self.__initialize_psu()
             self.__initialize_eeprom()
             self.__initialize_thermals()
+            self.__initialize_interrupts()
         else:
             self.__initialize_components()
 
@@ -84,6 +98,46 @@ class Chassis(ChassisBase):
         for index in range(0, NUM_COMPONENT):
             component = Component(index)
             self._component_list.append(component)
+
+    def __initialize_interrupts(self):
+        # Initial Interrupt MASK for QSFP, SFP
+        sfp_info_obj = {}
+
+        present_en = 0x10
+        Rxlos_IntL_en = 0x01
+        event_mask = present_en
+
+        for index in range(NUM_SFP):
+            port_num = index + 1
+            if port_num in range(SFP_PORT_START, SFP_PORT_END+1):
+                port_name = "SFP{}".format(str(port_num - SFP_PORT_START + 1))
+                port_type = "sfp"
+                sysfs_prs_file = "{}_modabs".format(port_type)
+            elif port_num in range(QSFP_PORT_START, QSFP_PORT_END+1):
+                port_name = "QSFP{}".format(str(port_num - QSFP_PORT_START + 1))
+                port_type = "qsfp"
+                sysfs_prs_file = "{}_modprs".format(port_type)
+
+            sfp_info_obj[index] = {}
+            sfp_info_obj[index]['intmask_sysfs'] = PATH_INTMASK_SYSFS.format(
+                PORT_INFO_PATH,
+                port_name = port_name,
+                type_prefix = port_type)
+
+            sfp_info_obj[index]['int_sysfs'] = PATH_INT_SYSFS.format(
+                PORT_INFO_PATH,
+                port_name = port_name,
+                type_prefix = port_type)
+
+            sfp_info_obj[index]['prs_sysfs'] = PATH_PRS_SYSFS.format(
+                PORT_INFO_PATH,
+                port_name = port_name,
+                prs_file_name = sysfs_prs_file)
+
+            self._api_helper.write_file(
+                sfp_info_obj[index]["intmask_sysfs"], hex(event_mask))
+
+        self.sfp_info_obj = sfp_info_obj
 
     def get_base_mac(self):
         """
@@ -260,3 +314,83 @@ class Chassis(ChassisBase):
             A boolean value, True if device is operating properly, False if not
         """
         return True
+
+    ##############################################################
+    ###################### Event methods #########################
+    ##############################################################
+
+    def __is_port_device_present(self, port_idx):
+        prs_path = self.sfp_info_obj[port_idx]["prs_sysfs"]
+        is_present = 1 - int(self._api_helper.read_txt_file(prs_path))
+        return is_present
+
+    def __update_port_event_object(self, interrup_devices):
+        port_dict = {}
+        event_obj = {'sfp':port_dict}
+        for port_idx in interrup_devices:
+            device_id = str(port_idx + 1)
+            port_dict[device_id] = str(self.__is_port_device_present(port_idx))
+
+        if len(port_dict):
+            event_obj['sfp'] = port_dict
+
+        return event_obj
+
+    def __check_all_port_interrupt_event(self):
+        interrupt_devices = {}
+        for i in range(NUM_SFP):
+            int_sysfs = self.sfp_info_obj[i]["int_sysfs"]
+            interrupt_flags = self._api_helper.read_txt_file(int_sysfs)
+            if interrupt_flags != '0x00':
+                interrupt_devices[i] = 1
+        return interrupt_devices
+
+    def get_change_event(self, timeout=0):
+        """
+        Returns a nested dictionary containing all devices which have
+        experienced a change at chassis level
+        Args:
+            timeout: Timeout in milliseconds (optional). If timeout == 0,
+                this method will block until a change is detected.
+        Returns:
+            (bool, dict):
+                - True if call successful, False if not;
+                - A nested dictionary where key is a device type,
+                  value is a dictionary with key:value pairs in the
+                  format of {'device_id':'device_event'},
+                  where device_id is the device ID for this device and
+                        device_event,
+                             status='1' represents device inserted,
+                             status='0' represents device removed.
+                  Ex. {'fan':{'0':'0', '2':'1'}, 'sfp':{'11':'0'}}
+                      indicates that fan 0 has been removed, fan 2
+                      has been inserted and sfp 11 has been removed.
+        """
+        if timeout == 0:
+            timer = self.POLL_INTERVAL
+            while True:
+                interrupt_devices = self.__check_all_port_interrupt_event()
+                if len(interrupt_devices):
+                    break
+                else:
+                    time.sleep(timer)
+            events_dict = self.__update_port_event_object(interrupt_devices)
+            return (True, events_dict)
+        else:
+            timeout = timeout / float(1000)
+            timer = min(timeout, self.POLL_INTERVAL)
+
+            while True:
+                start_time = time.time()
+                interrupt_devices = self.__check_all_port_interrupt_event()
+                if len(interrupt_devices):
+                    break
+
+                if timeout <= 0:
+                    break
+                else:
+                    time.sleep(timer)
+                elasped_time = time.time() - start_time
+                timeout = round(timeout - elasped_time, 3)
+            events_dict = self.__update_port_event_object(interrupt_devices)
+            return (True, events_dict)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Implement polling method to get port insert/remove event in Celestica/ questone2bd.= platform.

**- How I did it**
- Add sysfs for each port interrupt status.
- Implement get_change_event() in platform chassis. 

**- How to verify it**
- Run the mock up test on chassis.get_change_event()
- Insert/remove the transceiver and check the syslog.
[test_result.zip](https://github.com/SONIC-DEV/sonic-buildimage/files/4769773/test_result.zip)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Add XCVR insert/remove event support in questone2bd. 

**- A picture of a cute animal (not mandatory but encouraged)**
