### PR TITLE
[device/celestica]: Add support for fan/voltage event to questone2bd get_change_event api

### DIFF
--- a/device/celestica/x86_64-cel_questone2bd-r0/sonic_platform/chassis.py
+++ b/device/celestica/x86_64-cel_questone2bd-r0/sonic_platform/chassis.py
@@ -93,47 +93,6 @@ class Chassis(ChassisBase):
             component = Component(index)
             self._component_list.append(component)
 
-    # def __initialize_interrupts(self):
-    #     # Initial Interrupt MASK for QSFP, SFP
-    #     sfp_info_obj = {}
-
-    #     present_en = 0x10
-    #     Rxlos_IntL_en = 0x01
-    #     event_mask = present_en
-
-    #     for index in range(NUM_SFP):
-    #         port_num = index + 1
-    #         if port_num in range(SFP_PORT_START, SFP_PORT_END+1):
-    #             port_name = "SFP{}".format(str(port_num - SFP_PORT_START + 1))
-    #             port_type = "sfp"
-    #             sysfs_prs_file = "{}_modabs".format(port_type)
-    #         elif port_num in range(QSFP_PORT_START, QSFP_PORT_END+1):
-    #             port_name = "QSFP{}".format(
-    #                 str(port_num - QSFP_PORT_START + 1))
-    #             port_type = "qsfp"
-    #             sysfs_prs_file = "{}_modprs".format(port_type)
-
-    #         sfp_info_obj[index] = {}
-    #         sfp_info_obj[index]['intmask_sysfs'] = PATH_INTMASK_SYSFS.format(
-    #             PORT_INFO_PATH,
-    #             port_name=port_name,
-    #             type_prefix=port_type)
-
-    #         sfp_info_obj[index]['int_sysfs'] = PATH_INT_SYSFS.format(
-    #             PORT_INFO_PATH,
-    #             port_name=port_name,
-    #             type_prefix=port_type)
-
-    #         sfp_info_obj[index]['prs_sysfs'] = PATH_PRS_SYSFS.format(
-    #             PORT_INFO_PATH,
-    #             port_name=port_name,
-    #             prs_file_name=sysfs_prs_file)
-
-    #         self._api_helper.write_file(
-    #             sfp_info_obj[index]["intmask_sysfs"], hex(event_mask))
-
-    #     self.sfp_info_obj = sfp_info_obj
-
     def get_base_mac(self):
         """
         Retrieves the base MAC address for the chassis

--- a/device/celestica/x86_64-cel_questone2bd-r0/sonic_platform/chassis.py
+++ b/device/celestica/x86_64-cel_questone2bd-r0/sonic_platform/chassis.py
@@ -48,7 +48,6 @@ class Chassis(ChassisBase):
         self.sfp_module_initialized = False
         self.fan_module_initialized = False
         self.__initialize_eeprom()
-        self.__initialize_fan()
 
         if not self._api_helper.is_host():
             self.__initialize_fan()

--- a/device/celestica/x86_64-cel_questone2bd-r0/sonic_platform/chassis.py
+++ b/device/celestica/x86_64-cel_questone2bd-r0/sonic_platform/chassis.py
@@ -38,11 +38,6 @@ TLV_EEPROM_I2C_ADDR = 56
 BASE_CPLD_PLATFORM = "questone2bd.cpldb"
 BASE_GETREG_PATH = "/sys/devices/platform/{}/getreg".format(BASE_CPLD_PLATFORM)
 
-SWITCH_BRD_PLATFORM = "questone2bd.switchboard"
-PORT_INFO_PATH = "/sys/devices/platform/{}/SFF".format(SWITCH_BRD_PLATFORM)
-PATH_INT_SYSFS = "{0}/{port_name}/{type_prefix}_isr_flags"
-PATH_INTMASK_SYSFS = "{0}/{port_name}/{type_prefix}_isr_mask"
-PATH_PRS_SYSFS = "{0}/{port_name}/{prs_file_name}"
 
 class Chassis(ChassisBase):
     """Platform-specific Chassis class"""
@@ -51,14 +46,13 @@ class Chassis(ChassisBase):
         ChassisBase.__init__(self)
         self._api_helper = APIHelper()
         self.sfp_module_initialized = False
+        self.fan_module_initialized = False
         self.__initialize_eeprom()
-        self.POLL_INTERVAL = 1
 
         if not self._api_helper.is_host():
             self.__initialize_fan()
             self.__initialize_psu()
             self.__initialize_thermals()
-            self.__initialize_interrupts()
         else:
             self.__initialize_components()
 
@@ -81,6 +75,7 @@ class Chassis(ChassisBase):
             for fan_index in range(0, NUM_FAN):
                 fan = Fan(fant_index, fan_index)
                 self._fan_list.append(fan)
+        self.fan_module_initialized = True
 
     def __initialize_thermals(self):
         from sonic_platform.thermal import Thermal
@@ -98,45 +93,46 @@ class Chassis(ChassisBase):
             component = Component(index)
             self._component_list.append(component)
 
-    def __initialize_interrupts(self):
-        # Initial Interrupt MASK for QSFP, SFP
-        sfp_info_obj = {}
+    # def __initialize_interrupts(self):
+    #     # Initial Interrupt MASK for QSFP, SFP
+    #     sfp_info_obj = {}
 
-        present_en = 0x10
-        Rxlos_IntL_en = 0x01
-        event_mask = present_en
+    #     present_en = 0x10
+    #     Rxlos_IntL_en = 0x01
+    #     event_mask = present_en
 
-        for index in range(NUM_SFP):
-            port_num = index + 1
-            if port_num in range(SFP_PORT_START, SFP_PORT_END+1):
-                port_name = "SFP{}".format(str(port_num - SFP_PORT_START + 1))
-                port_type = "sfp"
-                sysfs_prs_file = "{}_modabs".format(port_type)
-            elif port_num in range(QSFP_PORT_START, QSFP_PORT_END+1):
-                port_name = "QSFP{}".format(str(port_num - QSFP_PORT_START + 1))
-                port_type = "qsfp"
-                sysfs_prs_file = "{}_modprs".format(port_type)
+    #     for index in range(NUM_SFP):
+    #         port_num = index + 1
+    #         if port_num in range(SFP_PORT_START, SFP_PORT_END+1):
+    #             port_name = "SFP{}".format(str(port_num - SFP_PORT_START + 1))
+    #             port_type = "sfp"
+    #             sysfs_prs_file = "{}_modabs".format(port_type)
+    #         elif port_num in range(QSFP_PORT_START, QSFP_PORT_END+1):
+    #             port_name = "QSFP{}".format(
+    #                 str(port_num - QSFP_PORT_START + 1))
+    #             port_type = "qsfp"
+    #             sysfs_prs_file = "{}_modprs".format(port_type)
 
-            sfp_info_obj[index] = {}
-            sfp_info_obj[index]['intmask_sysfs'] = PATH_INTMASK_SYSFS.format(
-                PORT_INFO_PATH,
-                port_name = port_name,
-                type_prefix = port_type)
+    #         sfp_info_obj[index] = {}
+    #         sfp_info_obj[index]['intmask_sysfs'] = PATH_INTMASK_SYSFS.format(
+    #             PORT_INFO_PATH,
+    #             port_name=port_name,
+    #             type_prefix=port_type)
 
-            sfp_info_obj[index]['int_sysfs'] = PATH_INT_SYSFS.format(
-                PORT_INFO_PATH,
-                port_name = port_name,
-                type_prefix = port_type)
+    #         sfp_info_obj[index]['int_sysfs'] = PATH_INT_SYSFS.format(
+    #             PORT_INFO_PATH,
+    #             port_name=port_name,
+    #             type_prefix=port_type)
 
-            sfp_info_obj[index]['prs_sysfs'] = PATH_PRS_SYSFS.format(
-                PORT_INFO_PATH,
-                port_name = port_name,
-                prs_file_name = sysfs_prs_file)
+    #         sfp_info_obj[index]['prs_sysfs'] = PATH_PRS_SYSFS.format(
+    #             PORT_INFO_PATH,
+    #             port_name=port_name,
+    #             prs_file_name=sysfs_prs_file)
 
-            self._api_helper.write_file(
-                sfp_info_obj[index]["intmask_sysfs"], hex(event_mask))
+    #         self._api_helper.write_file(
+    #             sfp_info_obj[index]["intmask_sysfs"], hex(event_mask))
 
-        self.sfp_info_obj = sfp_info_obj
+    #     self.sfp_info_obj = sfp_info_obj
 
     def get_base_mac(self):
         """
@@ -304,78 +300,82 @@ class Chassis(ChassisBase):
     ###################### Event methods #########################
     ##############################################################
 
-    def __is_port_device_present(self, port_idx):
-        prs_path = self.sfp_info_obj[port_idx]["prs_sysfs"]
-        is_present = 1 - int(self._api_helper.read_txt_file(prs_path))
-        return is_present
-
-    def __update_port_event_object(self, interrup_devices):
-        port_dict = {}
-        event_obj = {'sfp':port_dict}
-        for port_idx in interrup_devices:
-            device_id = str(port_idx + 1)
-            port_dict[device_id] = str(self.__is_port_device_present(port_idx))
-
-        if len(port_dict):
-            event_obj['sfp'] = port_dict
-
-        return event_obj
-
-    def __check_all_port_interrupt_event(self):
-        interrupt_devices = {}
-        for i in range(NUM_SFP):
-            int_sysfs = self.sfp_info_obj[i]["int_sysfs"]
-            interrupt_flags = self._api_helper.read_txt_file(int_sysfs)
-            if interrupt_flags != '0x00':
-                interrupt_devices[i] = 1
-        return interrupt_devices
-
     def get_change_event(self, timeout=0):
         """
         Returns a nested dictionary containing all devices which have
         experienced a change at chassis level
+
         Args:
             timeout: Timeout in milliseconds (optional). If timeout == 0,
                 this method will block until a change is detected.
+
         Returns:
             (bool, dict):
-                - True if call successful, False if not;
-                - A nested dictionary where key is a device type,
-                  value is a dictionary with key:value pairs in the
-                  format of {'device_id':'device_event'},
-                  where device_id is the device ID for this device and
-                        device_event,
-                             status='1' represents device inserted,
-                             status='0' represents device removed.
-                  Ex. {'fan':{'0':'0', '2':'1'}, 'sfp':{'11':'0'}}
-                      indicates that fan 0 has been removed, fan 2
-                      has been inserted and sfp 11 has been removed.
+                - bool: True if call successful, False if not;
+                - dict: A nested dictionary where key is a device type,
+                        value is a dictionary with key:value pairs in the format of
+                        {'device_id':'device_event'}, where device_id is the device ID
+                        for this device and device_event.
+                        The known devices's device_id and device_event was defined as table below.
+                         -----------------------------------------------------------------
+                         device   |     device_id       |  device_event  |  annotate
+                         -----------------------------------------------------------------
+                         'fan'          '<fan number>'     '0'              Fan inserted
+                                                           '1'              Fan removed
+
+                         'sfp'          '<sfp number>'     '0'              Sfp pluged in
+                                                           '1'              Sfp pluged out
+                                                           '2'              I2C bus stuck
+                                                           '3'              Bad eeprom
+                                                           '4'              Unsupported cable
+                                                           '5'              High Temperature
+                                                           '6'              Bad cable
+
+                         'voltage'      '<monitor point>'  '0'              Vout normal
+                                                           '1'              Vout abnormal
+                         --------------------------------------------------------------------
+                  Ex. {'fan':{'0':'0', '2':'1'}, 'sfp':{'11':'0'}, 'sfp':{'12':'1'},
+                       'voltage':{'U20':'1', 'U1':'0'}}
+                  Indicates that:
+                     fan 0 has been removed, fan 2 has been inserted.
+                     sfp 11 has been removed, sfp 12 has been inserted.
+                     monitored voltage U20 became abnormal, voltage U21 became normal.
+                  Note: For sfp, when event 3-6 happened, the module will not be avalaible,
+                        XCVRD shall stop to read eeprom before SFP recovered from error status.
         """
-        if timeout == 0:
-            timer = self.POLL_INTERVAL
-            while True:
-                interrupt_devices = self.__check_all_port_interrupt_event()
-                if len(interrupt_devices):
-                    break
-                else:
-                    time.sleep(timer)
-            events_dict = self.__update_port_event_object(interrupt_devices)
-            return (True, events_dict)
-        else:
-            timeout = timeout / float(1000)
-            timer = min(timeout, self.POLL_INTERVAL)
+        from sonic_platform.event import FanEvent, SfpEvent, VoltageEvent, POLL_INTERVAL
 
-            while True:
-                start_time = time.time()
-                interrupt_devices = self.__check_all_port_interrupt_event()
-                if len(interrupt_devices):
-                    break
+        if not self.fan_module_initialized:
+            self.__initialize_fan()
 
-                if timeout <= 0:
-                    break
-                else:
-                    time.sleep(timer)
-                elasped_time = time.time() - start_time
-                timeout = round(timeout - elasped_time, 3)
-            events_dict = self.__update_port_event_object(interrupt_devices)
-            return (True, events_dict)
+        if not self.sfp_module_initialized:
+            self.__initialize_sfp()
+
+        fan_event = FanEvent(self._fan_list)
+        sfp_event = SfpEvent(self._sfp_list)
+        voltage_event = VoltageEvent()
+
+        cur_fan_state = fan_event.get_fan_state()
+        start_milli_time = int(round(time.time() * 1000))
+        int_sfp, int_fan, int_volt = {}, {}, {}
+
+        while True:
+            chk_sfp = sfp_event.check_all_port_interrupt_event()
+            int_sfp = sfp_event.update_port_event_object(
+                chk_sfp, int_sfp) if chk_sfp else int_sfp
+            int_fan = fan_event.check_fan_status(cur_fan_state, int_fan)
+            int_volt = voltage_event.get_voltage_int()
+
+            current_milli_time = int(round(time.time() * 1000))
+            if timeout == 0 and (int_sfp or int_fan or int_volt) or \
+                    timeout != 0 and (current_milli_time - start_milli_time > timeout):
+                break
+
+            time.sleep(POLL_INTERVAL)
+
+        change_dict = dict()
+        change_dict['fan'] = int_fan
+        change_dict['sfp'] = int_sfp
+        change_dict['voltage'] = int_volt
+
+        return True, change_dict

--- a/device/celestica/x86_64-cel_questone2bd-r0/sonic_platform/event.py
+++ b/device/celestica/x86_64-cel_questone2bd-r0/sonic_platform/event.py
@@ -101,8 +101,8 @@ class SfpEvent:
 class FanEvent:
     ''' Listen to insert/remove fan events '''
 
-    FAN_INSERT_STATE = '0'
-    FAN_REMOVE_STATE = '1'
+    FAN_INSERT_STATE = '1'
+    FAN_REMOVE_STATE = '0'
 
     def __init__(self, fan_list):
         self.fan_list = fan_list
@@ -190,15 +190,15 @@ class VoltageEvent:
             PLATFORM_PATH, SWITCH_BRD_PLATFORM, self.VOLTAGE_PATH)
         self.voltage_idx = [0, 1, 8]
         self._api_helper = APIHelper()
-        self.voltage_scale = self.get_voltage_scale()
+        self.voltage_scale = self._get_voltage_scale()
 
-    def get_voltage_scale(self):
+    def _get_voltage_scale(self):
         voltage_scale_path = os.path.join(
             self.voltage_path, self.VOLTAGE_SCALE_SYSFS)
         get_voltage_scale = self._api_helper.read_txt_file(voltage_scale_path)
         return float(get_voltage_scale)
 
-    def get_voltage_int(self):
+    def get_voltage_state(self):
         voltage_mv_dict = {}
         for idx in range(0, len(self.VOLTAGE_CONFIG)):
             voltage_raw_path = os.path.join(
@@ -213,6 +213,14 @@ class VoltageEvent:
             max_v = self.VOLTAGE_CONFIG[idx]['max']
             min_v = self.VOLTAGE_CONFIG[idx]['min']
 
+            voltage_mv_dict[v_name] = self.VOLTAGE_NORMAL_EVENT
             if voltage_mV > max_v or voltage_mV < min_v:
                 voltage_mv_dict[v_name] = self.VOLTAGE_ABNORMAL_EVENT
         return voltage_mv_dict
+
+    def check_voltage_status(self, cur_voltage_dict, int_voltage):
+        voltage_dict = self.get_voltage_state()
+        for v_name in voltage_dict:
+            if voltage_dict[v_name] != cur_voltage_dict[v_name]:
+                int_voltage[v_name] = voltage_dict[v_name]
+        return int_voltage

--- a/device/celestica/x86_64-cel_questone2bd-r0/sonic_platform/event.py
+++ b/device/celestica/x86_64-cel_questone2bd-r0/sonic_platform/event.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python
+
+#############################################################################
+# Celestica
+#
+#############################################################################
+
+import time
+import os
+
+from fan import Fan
+from helper import APIHelper
+
+
+PLATFORM_PATH = "/sys/devices/platform/"
+SWITCH_BRD_PLATFORM = "questone2bd.switchboard"
+POLL_INTERVAL = 1
+
+
+class SfpEvent:
+    ''' Listen to insert/remove sfp events '''
+
+    PORT_INFO_DIR = 'SFF'
+    PATH_INT_SYSFS = "{0}/{port_name}/{type_prefix}_isr_flags"
+    PATH_INTMASK_SYSFS = "{0}/{port_name}/{type_prefix}_isr_mask"
+    PATH_PRS_SYSFS = "{0}/{port_name}/{prs_file_name}"
+    PRESENT_EN = 0x10
+
+    SFP_PORT_START = 1
+    SFP_PORT_END = 48
+    QSFP_PORT_START = 49
+    QSFP_PORT_END = 56
+
+    def __init__(self, sfp_list):
+        self.num_sfp = len(sfp_list)
+        self._api_helper = APIHelper()
+        self.__initialize_interrupts()
+
+    def __initialize_interrupts(self):
+        # Initial Interrupt MASK for QSFP, SFP
+
+        sfp_info_obj = {}
+        port_info_path = os.path.join(
+            PLATFORM_PATH, SWITCH_BRD_PLATFORM, self.PORT_INFO_DIR)
+
+        for index in range(self.num_sfp):
+            port_num = index + 1
+            if port_num in range(self.SFP_PORT_START, self.SFP_PORT_END+1):
+                port_name = "SFP{}".format(
+                    str(port_num - self.SFP_PORT_START + 1))
+                port_type = "sfp"
+                sysfs_prs_file = "{}_modabs".format(port_type)
+            elif port_num in range(self.QSFP_PORT_START, self.QSFP_PORT_END+1):
+                port_name = "QSFP{}".format(
+                    str(port_num - self.QSFP_PORT_START + 1))
+                port_type = "qsfp"
+                sysfs_prs_file = "{}_modprs".format(port_type)
+
+            sfp_info_obj[index] = {}
+            sfp_info_obj[index]['intmask_sysfs'] = self.PATH_INTMASK_SYSFS.format(
+                port_info_path,
+                port_name=port_name,
+                type_prefix=port_type)
+
+            sfp_info_obj[index]['int_sysfs'] = self.PATH_INT_SYSFS.format(
+                port_info_path,
+                port_name=port_name,
+                type_prefix=port_type)
+
+            sfp_info_obj[index]['prs_sysfs'] = self.PATH_PRS_SYSFS.format(
+                port_info_path,
+                port_name=port_name,
+                prs_file_name=sysfs_prs_file)
+
+            self._api_helper.write_file(
+                sfp_info_obj[index]["intmask_sysfs"], hex(self.PRESENT_EN))
+
+        self.sfp_info_obj = sfp_info_obj
+
+    def __is_port_device_present(self, port_idx):
+        prs_path = self.sfp_info_obj[port_idx]["prs_sysfs"]
+        is_present = 1 - int(self._api_helper.read_txt_file(prs_path))
+        return is_present
+
+    def update_port_event_object(self, interrup_devices, port_dict):
+        for port_idx in interrup_devices:
+            device_id = str(port_idx + 1)
+            port_dict[device_id] = str(self.__is_port_device_present(port_idx))
+        return port_dict
+
+    def check_all_port_interrupt_event(self):
+        interrupt_devices = {}
+        for i in range(self.num_sfp):
+            int_sysfs = self.sfp_info_obj[i]["int_sysfs"]
+            interrupt_flags = self._api_helper.read_txt_file(int_sysfs)
+            if interrupt_flags != '0x00':
+                interrupt_devices[i] = 1
+        return interrupt_devices
+
+
+class FanEvent:
+    ''' Listen to insert/remove fan events '''
+
+    FAN_INSERT_STATE = '0'
+    FAN_REMOVE_STATE = '1'
+
+    def __init__(self, fan_list):
+        self.fan_list = fan_list
+
+    def get_fan_state(self):
+        fan_dict = {}
+        for idx, fan in enumerate(self.fan_list):
+            fan_dict[idx] = self.FAN_INSERT_STATE if fan.get_presence(
+            ) else self.FAN_REMOVE_STATE
+        return fan_dict
+
+    def check_fan_status(self, cur_fan_dict, fan_dict):
+        for idx, fan in enumerate(self.fan_list):
+            presence = fan.get_presence()
+            if(presence and cur_fan_dict[idx] == self.FAN_REMOVE_STATE):
+                fan_dict[idx] = self.FAN_INSERT_STATE
+            elif(not presence and cur_fan_dict[idx] == self.FAN_INSERT_STATE):
+                fan_dict[idx] = self.FAN_REMOVE_STATE
+        return fan_dict
+
+
+class VoltageEvent:
+    ''' Listen to abnormal voltage events '''
+
+    VOLTAGE_PATH = "ocores-i2c-polling/i2c-71/71-0035/iio:device0"
+    VOLTAGE_SCALE_SYSFS = "in_voltage_scale"
+    VOLTAGE_RAW_SYSFS = "in_voltage{}_raw"
+    VOLTAGE_CONFIG = {
+        0: {
+            'name': 'XP3R3V_FD',
+            'max': 3470,
+            'min': 3140
+        },
+        1: {
+            'name': 'XP3R3V',
+            'max': 3470,
+            'min': 3140
+        },
+        2: {
+            'name': 'XP1R82V',
+            'max': 1950,
+            'min': 1470
+        },
+        3: {
+            'name': 'XP1R05V',
+            'max': 1068,
+            'min': 1032
+        },
+        4: {
+            'name': 'XP1R7V',
+            'max': 1785,
+            'min': 1615
+        },
+        5: {
+            'name': 'XP1R2V',
+            'max': 1260,
+            'min': 1140
+        },
+        6: {
+            'name': 'XP1R3V',
+            'max': 1352,
+            'min': 1248
+        },
+        7: {
+            'name': 'XP1R5V',
+            'max': 1580,
+            'min': 1430
+        },
+        8: {
+            'name': 'XP2R5V',
+            'max': 2750,
+            'min': 2375
+        },
+        9: {
+            'name': 'XP0R6V_VTT',
+            'max': 632,
+            'min': 568
+        },
+    }
+    VOLTAGE_NORMAL_EVENT = '0'
+    VOLTAGE_ABNORMAL_EVENT = '1'
+
+    def __init__(self):
+        self.voltage_path = os.path.join(
+            PLATFORM_PATH, SWITCH_BRD_PLATFORM, self.VOLTAGE_PATH)
+        self.voltage_idx = [0, 1, 8]
+        self._api_helper = APIHelper()
+        self.voltage_scale = self.get_voltage_scale()
+
+    def get_voltage_scale(self):
+        voltage_scale_path = os.path.join(
+            self.voltage_path, self.VOLTAGE_SCALE_SYSFS)
+        get_voltage_scale = self._api_helper.read_txt_file(voltage_scale_path)
+        return float(get_voltage_scale)
+
+    def get_voltage_int(self):
+        voltage_mv_dict = {}
+        for idx in range(0, len(self.VOLTAGE_CONFIG)):
+            voltage_raw_path = os.path.join(
+                self.voltage_path, self.VOLTAGE_RAW_SYSFS.format(idx))
+            in_voltageX_raw = self._api_helper.read_txt_file(voltage_raw_path)
+
+            voltage_mV = float(in_voltageX_raw) * self.voltage_scale
+            if idx in self.voltage_idx:
+                voltage_mV *= 2
+
+            v_name = self.VOLTAGE_CONFIG[idx]['name']
+            max_v = self.VOLTAGE_CONFIG[idx]['max']
+            min_v = self.VOLTAGE_CONFIG[idx]['min']
+
+            if voltage_mV > max_v or voltage_mV < min_v:
+                voltage_mv_dict[v_name] = self.VOLTAGE_ABNORMAL_EVENT
+        return voltage_mv_dict


### PR DESCRIPTION
**- What I did**
- Implement polling method to get fan insert/remove event in questone2bd platform api
- Implement polling method to get voltage over threshold event in questone2bd platform api

**- How I did it**
- Modify get_change_event() in platform chassis. 
- Add event.py to store VoltageEvent, FanEvent and SfpEvent class

**- How to verify it**
- Install voltage driver (https://github.com/SONIC-DEV/sonic-buildimage/pull/197)
- Run test script and set an event: [test_event.zip](https://github.com/SONIC-DEV/sonic-buildimage/files/4918227/test_event.zip)
- Test log: [test_event.log](https://github.com/SONIC-DEV/sonic-buildimage/files/4918230/test_event.log)






