### PR TITLE
[platform/cel-dx010]: Add python3 installer for sonic_platform package

### DIFF
--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/sfp.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/sfp.py
@@ -201,12 +201,10 @@ class Sfp(SfpBase):
         port_name = "Unknown"
         sfp_type = "Unknown"
 
-        if self.port_num >= QSFP_PORT_START and self.port_num <= QSFP_TYPE:
+        if self.port_num >= QSFP_PORT_START and self.port_num <= QSFP_PORT_END:
             sfp_type = QSFP_TYPE
             port_name = "QSFP" + str(self.port_num - QSFP_PORT_START + 1)
-        elif self.port_num >= SFP_PORT_START and self.port_num <= SFP_PORT_END:
-            sfp_type = SFP_TYPE
-            port_name = "SFP" + str(self.port_num - SFP_PORT_START + 1)
+
         return sfp_type, port_name
 
     def __convert_string_to_num(self, value_str):

--- a/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.install
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/platform-modules-dx010.install
@@ -5,4 +5,5 @@ dx010/scripts/fancontrol.sh etc/init.d
 dx010/scripts/fancontrol.service lib/systemd/system
 services/fancontrol/fancontrol  usr/local/bin
 dx010/modules/sonic_platform-1.0-py2-none-any.whl usr/share/sonic/device/x86_64-cel_seastone-r0
+dx010/modules/sonic_platform-1.0-py3-none-any.whl usr/share/sonic/device/x86_64-cel_seastone-r0
 services/platform_api/platform_api_mgnt.sh usr/local/bin

--- a/platform/broadcom/sonic-platform-modules-cel/debian/rules
+++ b/platform/broadcom/sonic-platform-modules-cel/debian/rules
@@ -13,13 +13,15 @@ MODULE_DIRS:= dx010 haliburton silverstone seastone2
 override_dh_auto_build:
 	(for mod in $(MODULE_DIRS); do \
 		make -C $(KERNEL_SRC)/build M=$(MOD_SRC_DIR)/$${mod}/modules; \
-		cd $(MOD_SRC_DIR)/$${mod}; \
-		python2.7 setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}/modules; \
-		cd $(MOD_SRC_DIR); \
 		if [ $$mod = "seastone2" ]; then \
 			cd services/platform_api; \
-			python2 setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}/modules; \
-		fi \
+			python2.7 setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}/modules; \
+			python3 setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}/modules; \
+			continue; \
+		fi; \
+		cd $(MOD_SRC_DIR)/$${mod}; \
+		python2.7 setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}/modules; \
+		python3 setup.py bdist_wheel -d $(MOD_SRC_DIR)/$${mod}/modules; \
 	done)
 
 override_dh_auto_install:

--- a/platform/broadcom/sonic-platform-modules-cel/services/platform_api/platform_api_mgnt.sh
+++ b/platform/broadcom/sonic-platform-modules-cel/services/platform_api/platform_api_mgnt.sh
@@ -4,12 +4,20 @@ PREV_REBOOT_CAUSE="/host/reboot-cause/"
 DEVICE="/usr/share/sonic/device"
 PLATFORM=$(/usr/local/bin/sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
 FILES=$DEVICE/$PLATFORM/api_files
+PY2_PACK=$DEVICE/$PLATFORM/sonic_platform-1.0-py2-none-any.whl
+PY3_PACK=$DEVICE/$PLATFORM/sonic_platform-1.0-py3-none-any.whl
 
 install() {
-    # Install sonic-platform package
-    if [ -e $DEVICE/$PLATFORM/sonic_platform-1.0-py2-none-any.whl ]; then
-        pip install $DEVICE/$PLATFORM/sonic_platform-1.0-py2-none-any.whl
+    # Install python2.7 sonic-platform package
+    if [ -e $PY2_PACK ]; then
+        pip install $PY2_PACK
     fi
+
+    # Install python3 sonic-platform package
+    if [ -e $PY3_PACK ]; then
+        pip3 install $PY3_PACK
+    fi
+
 }
 
 init() {


### PR DESCRIPTION
**- What I did**
- Add python3 installer for sonic_platform package

**- How I did it**

1. Add rule to compile sonic_platform package with python3
2. Add command to install python3 package of sonic_platform

**- How to verify it**
- sonic_platform must installed in this `/usr/local/lib/python3.7/dist-packages/sonic_platform` under sonic host and pmon docker


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
