### PR TITLE
watchdog platform too_big_timeout issue fix

### DIFF
--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/watchdog.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/watchdog.py
@@ -133,6 +133,8 @@ class Watchdog(WatchdogBase):
         ret = WDT_COMMON_ERROR
         if seconds < 0:
             return ret
+        if seconds > 16779:
+            return ret
 
         try:
             if self.timeout != seconds:

--- a/device/celestica/x86_64-cel_seastone-r0/sonic_platform/watchdog.py
+++ b/device/celestica/x86_64-cel_seastone-r0/sonic_platform/watchdog.py
@@ -136,6 +136,7 @@ class Watchdog(WatchdogBase):
         if seconds > 16779:
             return ret
 
+
         try:
             if self.timeout != seconds:
                 self.timeout = self._settimeout(seconds)


### PR DESCRIPTION
**- What I did**
fix watchdog platform too_big_timeout test case fail issue.

**- How I did it**
define the too_big_timeout to 0xffffff/1000 seconds in sonic mgmt repo test case.
check the too_big_timeout value in seastone sonic platform watchdog.py. 
If this input time out value > defined too_big_timeout, watchdog.py return -1.

**- How to verify it**
Verify it through pytest sonic platform test case.

